### PR TITLE
Fix two UI-related simulation errors

### DIFF
--- a/src/spec_generator/gui/tabs/antibody_tab.py
+++ b/src/spec_generator/gui/tabs/antibody_tab.py
@@ -1,5 +1,6 @@
 import os
 import threading
+from dataclasses import asdict
 from datetime import datetime
 from tkinter import (HORIZONTAL, LEFT, NORMAL, DISABLED, NSEW, SUNKEN, WORD,
                      StringVar, messagebox, Text, E)
@@ -183,8 +184,11 @@ class AntibodyTab(BaseTab):
             if not chains:
                 raise ValueError("No chains defined.")
 
-            assemblies = generate_assembly_combinations(chains)
-            assemblies_with_mass = calculate_assembly_masses(chains, assemblies)
+            # Convert chain objects to dicts for the logic functions
+            chains_as_dicts = [asdict(c) for c in chains]
+
+            assemblies = generate_assembly_combinations(chains_as_dicts)
+            assemblies_with_mass = calculate_assembly_masses(chains_as_dicts, assemblies)
 
             for assembly in assemblies_with_mass:
                 name = assembly['name']

--- a/src/spec_generator/gui/tabs/base_tab.py
+++ b/src/spec_generator/gui/tabs/base_tab.py
@@ -28,7 +28,7 @@ class BaseTab(ttk.Frame):
         """
         raise NotImplementedError
 
-    def _gather_common_params(self, params_dict, lc_params_dict):
+    def _gather_common_params(self, params_dict, lc_params_dict=None):
         seed_str = params_dict['seed_var'].get().strip()
         if seed_str:
             seed = int(seed_str)
@@ -50,14 +50,16 @@ class BaseTab(ttk.Frame):
             filename_template=params_dict['filename_template_var'].get(),
         )
 
-        lc_enabled = lc_params_dict['enabled_var'].get()
-        lc = LCParams(
-            enabled=lc_enabled,
-            num_scans=int(lc_params_dict['num_scans_entry'].get()) if lc_enabled else 1,
-            scan_interval=float(lc_params_dict['scan_interval_entry'].get()) if lc_enabled else 0.0,
-            gaussian_std_dev=float(lc_params_dict['gaussian_std_dev_entry'].get()) if lc_enabled else 0.0,
-            lc_tailing_factor=float(lc_params_dict['lc_tailing_factor_entry'].get()) if lc_enabled else 0.0,
-        )
+        lc = None
+        if lc_params_dict:
+            lc_enabled = lc_params_dict['enabled_var'].get()
+            lc = LCParams(
+                enabled=lc_enabled,
+                num_scans=int(lc_params_dict['num_scans_entry'].get()) if lc_enabled else 1,
+                scan_interval=float(lc_params_dict['scan_interval_entry'].get()) if lc_enabled else 0.0,
+                gaussian_std_dev=float(lc_params_dict['gaussian_std_dev_entry'].get()) if lc_enabled else 0.0,
+                lc_tailing_factor=float(lc_params_dict['lc_tailing_factor_entry'].get()) if lc_enabled else 0.0,
+            )
         return common, lc
 
     def get_log_widgets(self):


### PR DESCRIPTION
This commit addresses two separate errors that were causing simulations to fail from the GUI.

1.  **Antibody Tab Preview:** A `TypeError` was occurring because `Chain` objects were passed directly to logic functions expecting dictionaries. This is fixed by converting the objects to dictionaries using `asdict` within the `_preview_assemblies_command` in `antibody_tab.py`, aligning its behavior with the full simulation worker.

2.  **Peptide Map Tab:** A `TypeError` occurred because the `_gather_common_params` method was called without the required `lc_params_dict`. This happened because the Peptide Map tab manages its own LC parameters differently. The fix makes the `lc_params_dict` argument optional in the `base_tab.py` method, allowing tabs without the standard LC parameter frame to call it without causing a crash.