### PR TITLE
Refactor(logic): Decouple simulation logic from GUI with callbacks

### DIFF
--- a/src/spec_generator/logic/binding.py
+++ b/src/spec_generator/logic/binding.py
@@ -55,7 +55,7 @@ def execute_binding_simulation(
             seed=common.seed,
             noise_option=common.noise_option,
             pink_noise_enabled=common.pink_noise_enabled,
-            update_queue=None
+            progress_callback=None
         )
 
         # 3. Create mzML content
@@ -63,7 +63,7 @@ def execute_binding_simulation(
             mz_range=mz_range,
             run_data=[final_spectra], # Wrap in list for mzML writer
             scan_interval=lc.scan_interval,
-            update_queue=None
+            progress_callback=None
         )
         if not mzml_content:
             return False, ""

--- a/src/spec_generator/logic/simulation.py
+++ b/src/spec_generator/logic/simulation.py
@@ -9,7 +9,133 @@ from ..core.spectrum import generate_protein_spectrum
 from ..utils.mzml import create_mzml_content_et
 from ..utils.file_io import create_unique_filename
 from ..config import SpectrumGeneratorConfig
+from .retention_time import calculate_apex_scans_from_hydrophobicity
 from collections import defaultdict
+
+
+class SimulationRunner:
+    """
+    Encapsulates the logic for running a full simulation from a configuration object.
+    """
+
+    def __init__(self, config: SpectrumGeneratorConfig, progress_callback=None):
+        """
+        Initializes the SimulationRunner.
+        Args:
+            config: The configuration object for the simulation.
+            progress_callback: An optional function to call with progress updates.
+                               It should accept (str, Any) where the first element
+                               is the type of update (e.g., 'log', 'progress_set')
+                               and the second is the value.
+        """
+        self.config = config
+        self.progress_callback = progress_callback or (lambda *args: None)
+
+    def _prepare_simulation_tasks(self, mz_range: np.ndarray) -> tuple[list, list[int]]:
+        """Prepares the list of tasks for the multiprocessing pool."""
+        tasks = []
+        num_sub_tasks = []
+        for i, protein_mass in enumerate(self.config.protein_masses):
+            if self.config.mass_inhomogeneity > 0:
+                num_samples = 7
+                mass_distribution = np.random.normal(
+                    loc=protein_mass,
+                    scale=self.config.mass_inhomogeneity,
+                    size=num_samples,
+                )
+                num_sub_tasks.append(num_samples)
+                for sub_mass in mass_distribution:
+                    tasks.append(
+                        (i, sub_mass, self.config.intensity_scalars[i], self.config, mz_range)
+                    )
+            else:
+                num_sub_tasks.append(1)
+                tasks.append(
+                    (i, protein_mass, self.config.intensity_scalars[i], self.config, mz_range)
+                )
+        return tasks, num_sub_tasks
+
+    def _aggregate_simulation_results(
+        self, results: list, num_sub_tasks: list[int]
+    ) -> list[np.ndarray]:
+        """Groups and averages the results from the multiprocessing pool."""
+        grouped_spectra = defaultdict(list)
+        for protein_index, spectrum in results:
+            grouped_spectra[protein_index].append(spectrum)
+
+        all_clean_spectra = []
+        for i in range(len(self.config.protein_masses)):
+            spectra_for_protein = grouped_spectra[i]
+            if num_sub_tasks[i] > 1:
+                avg_spectrum = np.sum(spectra_for_protein, axis=0) / num_sub_tasks[i]
+                all_clean_spectra.append(avg_spectrum)
+            else:
+                all_clean_spectra.append(spectra_for_protein[0])
+        return all_clean_spectra
+
+    def run(self) -> tuple[np.ndarray, list[np.ndarray]] | None:
+        """
+        Executes the core simulation logic to generate spectra data.
+        """
+        common = self.config.common
+        lc = self.config.lc
+
+        log_msg = (
+            f"  Proteins: {len(self.config.protein_masses)} ({', '.join(map(str, self.config.protein_masses))})\n"
+            f"  m/z Range: {common.mz_range_start}-{common.mz_range_end}, Step: {common.mz_step}\n"
+            f"  Isotopes: {'Enabled' if common.isotopic_enabled else 'Disabled'}, Resolution: {common.resolution/1000}k\n"
+            f"  LC Simulation: {'Enabled' if lc.enabled else 'Disabled'} ({lc.num_scans} scans)\n"
+            f"  Noise: {common.noise_option}, Seed: {common.seed}\n"
+        )
+        self.progress_callback("log", log_msg)
+        self.progress_callback("progress_set", 5)
+
+        mz_range = np.arange(
+            common.mz_range_start, common.mz_range_end + common.mz_step, common.mz_step
+        )
+
+        tasks, num_sub_tasks = self._prepare_simulation_tasks(mz_range)
+
+        self.progress_callback(
+            "log", f"Generating {len(tasks)} total spectra in parallel...\n"
+        )
+
+        with multiprocessing.Pool() as pool:
+            results = pool.starmap(_spectrum_generation_worker, tasks)
+
+        all_clean_spectra = self._aggregate_simulation_results(results, num_sub_tasks)
+
+        if not all_clean_spectra:
+            self.progress_callback(
+                "error", "Spectrum generation failed for an unknown reason."
+            )
+            return None
+
+        self.progress_callback("progress_set", 55)
+
+        apex_scans = None
+        if (
+            lc.enabled
+            and self.config.hydrophobicity_scores
+            and len(self.config.hydrophobicity_scores) == len(all_clean_spectra)
+        ):
+            apex_scans = calculate_apex_scans_from_hydrophobicity(
+                self.config.hydrophobicity_scores, lc.num_scans
+            )
+
+        combined_chromatogram = apply_lc_profile_and_noise(
+            mz_range=mz_range,
+            all_clean_spectra=all_clean_spectra,
+            num_scans=lc.num_scans,
+            gaussian_std_dev=lc.gaussian_std_dev,
+            lc_tailing_factor=lc.lc_tailing_factor,
+            seed=common.seed,
+            noise_option=common.noise_option,
+            pink_noise_enabled=common.pink_noise_enabled,
+            apex_scans=apex_scans,
+            progress_callback=self.progress_callback,
+        )
+        return mz_range, [combined_chromatogram]
 
 
 def _spectrum_generation_worker(
@@ -36,134 +162,13 @@ def _spectrum_generation_worker(
     return protein_index, spectrum
 
 
-def _run_simulation(
-    config: SpectrumGeneratorConfig, update_queue: queue.Queue | None
-) -> tuple[np.ndarray, list[np.ndarray]] | None:
-    """
-    Core simulation logic to generate spectra data.
-    """
-    common = config.common
-    lc = config.lc
-
-    if update_queue:
-        log_msg = (
-            f"  Proteins: {len(config.protein_masses)} ({', '.join(map(str, config.protein_masses))})\n"
-            f"  m/z Range: {common.mz_range_start}-{common.mz_range_end}, Step: {common.mz_step}\n"
-            f"  Isotopes: {'Enabled' if common.isotopic_enabled else 'Disabled'}, Resolution: {common.resolution/1000}k\n"
-            f"  LC Simulation: {'Enabled' if lc.enabled else 'Disabled'} ({lc.num_scans} scans)\n"
-            f"  Noise: {common.noise_option}, Seed: {common.seed}\n"
-        )
-        update_queue.put(("log", log_msg))
-        update_queue.put(("progress_set", 5))
-
-    mz_range = np.arange(
-        common.mz_range_start, common.mz_range_end + common.mz_step, common.mz_step
-    )
-
-    # Flatten the tasks: each call to generate_protein_spectrum becomes one task.
-    # This handles both multi-protein and mass inhomogeneity in one parallel step.
-    tasks = []
-    num_sub_tasks = []
-    for i, protein_mass in enumerate(config.protein_masses):
-        if config.mass_inhomogeneity > 0:
-            num_samples = 7
-            mass_distribution = np.random.normal(
-                loc=protein_mass, scale=config.mass_inhomogeneity, size=num_samples
-            )
-            num_sub_tasks.append(num_samples)
-            for sub_mass in mass_distribution:
-                tasks.append(
-                    (
-                        i,
-                        sub_mass,
-                        config.intensity_scalars[i],
-                        config,
-                        mz_range,
-                    )
-                )
-        else:
-            num_sub_tasks.append(1)
-            tasks.append(
-                (
-                    i,
-                    protein_mass,
-                    config.intensity_scalars[i],
-                    config,
-                    mz_range,
-                )
-            )
-
-    if update_queue:
-        update_queue.put(
-            ("log", f"Generating {len(tasks)} total spectra in parallel...\n")
-        )
-
-    with multiprocessing.Pool() as pool:
-        results = pool.starmap(_spectrum_generation_worker, tasks)
-
-    # Group and average the results
-    grouped_spectra = defaultdict(list)
-    for protein_index, spectrum in results:
-        grouped_spectra[protein_index].append(spectrum)
-
-    all_clean_spectra = []
-    for i in range(len(config.protein_masses)):
-        spectra_for_protein = grouped_spectra[i]
-        if num_sub_tasks[i] > 1:
-            # Average the spectra for mass inhomogeneity
-            avg_spectrum = np.sum(spectra_for_protein, axis=0) / num_sub_tasks[i]
-            all_clean_spectra.append(avg_spectrum)
-        else:
-            all_clean_spectra.append(spectra_for_protein[0])
-
-    if not all_clean_spectra:
-        if update_queue:
-            update_queue.put(
-                ("error", "Spectrum generation failed for an unknown reason.")
-            )
-        return None
-
-    if update_queue:
-        update_queue.put(("progress_set", 55))
-
-    apex_scans = None
-    if (
-        lc.enabled
-        and config.hydrophobicity_scores
-        and len(config.hydrophobicity_scores) == len(all_clean_spectra)
-    ):
-        scores = np.array(config.hydrophobicity_scores)
-        min_score, max_score = np.min(scores), np.max(scores)
-        if max_score == min_score:
-            apex_scans = [int(lc.num_scans / 2)] * len(scores)
-        else:
-            scan_padding = int(lc.num_scans * 0.1)
-            usable_scan_range = lc.num_scans - 2 * scan_padding
-            scaled_scans = (
-                (scores - min_score) / (max_score - min_score) * usable_scan_range
-            )
-            apex_scans = [int(s + scan_padding) for s in scaled_scans]
-
-    combined_chromatogram = apply_lc_profile_and_noise(
-        mz_range=mz_range,
-        all_clean_spectra=all_clean_spectra,
-        num_scans=lc.num_scans,
-        gaussian_std_dev=lc.gaussian_std_dev,
-        lc_tailing_factor=lc.lc_tailing_factor,
-        seed=common.seed,
-        noise_option=common.noise_option,
-        pink_noise_enabled=common.pink_noise_enabled,
-        apex_scans=apex_scans,
-        update_queue=update_queue,
-    )
-    return mz_range, [combined_chromatogram]
-
-
 def run_simulation_for_preview(config: SpectrumGeneratorConfig) -> tuple[np.ndarray, np.ndarray] | None:
     """
     Runs the core simulation and returns a single spectrum for previewing.
     """
-    simulation_result = _run_simulation(config, update_queue=None)
+    runner = SimulationRunner(config)
+    simulation_result = runner.run()
+
     if simulation_result:
         mz_range, spectra_data = simulation_result
         # For preview, we just need the apex scan of the first (and only) chromatogram
@@ -171,28 +176,31 @@ def run_simulation_for_preview(config: SpectrumGeneratorConfig) -> tuple[np.ndar
         return mz_range, spectra_data[0][apex_scan_index]
     return None
 
+
 def execute_simulation_and_write_mzml(
     config: SpectrumGeneratorConfig,
     final_filepath: str,
-    update_queue: queue.Queue | None,
+    progress_callback=None,
     return_data_only: bool = False,
 ) -> bool | tuple[np.ndarray, list[np.ndarray]]:
     """
     The main logic for running a simulation and writing the mzML file.
     Orchestrates the spectrum generation, scaling, noise addition, and file writing.
     """
+    progress_callback = progress_callback or (lambda *args: None)
     try:
         if not config.protein_masses or not all(m > 0 for m in config.protein_masses):
             raise ValueError("Protein masses must be positive numbers.")
         if config.common.mz_step <= 0:
             raise ValueError("m/z step must be positive.")
     except ValueError as e:
-        if update_queue:
-            update_queue.put(('error', f"Invalid parameters: {e}. Please check inputs."))
+        progress_callback('error', f"Invalid parameters: {e}. Please check inputs.")
         return False
 
     try:
-        simulation_result = _run_simulation(config, update_queue)
+        runner = SimulationRunner(config, progress_callback)
+        simulation_result = runner.run()
+
         if simulation_result is None:
             return False
 
@@ -202,38 +210,34 @@ def execute_simulation_and_write_mzml(
             return mz_range, spectra_for_mzml
 
         if not os.path.basename(final_filepath):
-            if update_queue:
-                update_queue.put(('error', "Filename template resulted in an empty name."))
+            progress_callback('error', "Filename template resulted in an empty name.")
             return False
 
         mzml_content = create_mzml_content_et(
-            mz_range, spectra_for_mzml,
+            mz_range,
+            spectra_for_mzml,
             config.lc.scan_interval if config.lc.enabled else 0.0,
-            update_queue
+            progress_callback,
         )
         if mzml_content is None:
             return False
 
-        if update_queue:
-            update_queue.put(('progress_set', 95))
+        progress_callback('progress_set', 95)
 
         unique_filepath = create_unique_filename(final_filepath)
         os.makedirs(os.path.dirname(unique_filepath), exist_ok=True)
 
-        if update_queue:
-            update_queue.put(('log', f"Writing mzML file to: {os.path.basename(unique_filepath)}\n"))
+        progress_callback('log', f"Writing mzML file to: {os.path.basename(unique_filepath)}\n")
 
         with open(unique_filepath, "wb") as outfile:
             outfile.write(mzml_content)
 
-        if update_queue:
-            update_queue.put(('log', "File successfully created.\n\n"))
-            update_queue.put(('progress_set', 100))
+        progress_callback('log', "File successfully created.\n\n")
+        progress_callback('progress_set', 100)
 
         return True
 
     except Exception as e:
-        if update_queue:
-            update_queue.put(('error', f"An unexpected error occurred: {e}"))
+        progress_callback('error', f"An unexpected error occurred: {e}")
         print(f"An unexpected error occurred: {e}")
         return False

--- a/src/spec_generator/logic/spectrum_logic.py
+++ b/src/spec_generator/logic/spectrum_logic.py
@@ -130,7 +130,10 @@ class SpectrumTabLogic:
         filename = format_filename(config.common.filename_template, placeholders)
         filepath = os.path.join(config.common.output_directory, filename)
 
-        success = execute_simulation_and_write_mzml(config, filepath, task_queue)
+        # The lambda function acts as a bridge between the callback system and the GUI queue
+        success = execute_simulation_and_write_mzml(
+            config, filepath, progress_callback=lambda type, value: task_queue.put((type, value))
+        )
 
         if success:
             task_queue.put(('done', "mzML file successfully created."))
@@ -143,6 +146,7 @@ class SpectrumTabLogic:
             if not config.protein_masses:
                 raise ValueError("Please enter at least one protein mass.")
 
+            # Note: run_simulation_for_preview is now decoupled and does not need a callback.
             simulation_result = run_simulation_for_preview(config)
             if simulation_result:
                 mz_range, preview_spectrum = simulation_result

--- a/tests/test_peptide_map.py
+++ b/tests/test_peptide_map.py
@@ -54,8 +54,7 @@ class TestPeptideMapSimulation(unittest.TestCase):
         # We don't have a queue in the test environment, so we pass None
         success = execute_peptide_map_simulation(
             config=config,
-            final_filepath=output_filepath,
-            update_queue=None
+            final_filepath=output_filepath
         )
 
         # 1. Check that the simulation reports success
@@ -87,7 +86,6 @@ class TestPeptideMapSimulation(unittest.TestCase):
         result = execute_peptide_map_simulation(
             config=config,
             final_filepath="",
-            update_queue=None,
             return_data_only=True
         )
 
@@ -125,7 +123,7 @@ class TestPeptideMapSimulation(unittest.TestCase):
         )
 
         mz_range, final_scans = execute_peptide_map_simulation(
-            config=config, final_filepath="", update_queue=None, return_data_only=True
+            config=config, final_filepath="", return_data_only=True
         )
 
         # Combine all scans to get the total signal
@@ -165,7 +163,7 @@ class TestPeptideMapSimulation(unittest.TestCase):
         )
 
         mz_range, final_scans = execute_peptide_map_simulation(
-            config=config, final_filepath="", update_queue=None, return_data_only=True
+            config=config, final_filepath="", return_data_only=True
         )
 
         total_signal = np.sum(final_scans, axis=0)
@@ -221,7 +219,7 @@ class TestPeptideMapSimulation(unittest.TestCase):
 
         # 1. Get the result from the parallel implementation
         mz_range_parallel, final_scans_parallel = execute_peptide_map_simulation(
-            config=config, final_filepath="", update_queue=None, return_data_only=True
+            config=config, final_filepath="", return_data_only=True
         )
 
         # 2. Manually run the sequential logic to get the expected result

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -47,7 +47,6 @@ class TestSimulation(unittest.TestCase):
         result = execute_simulation_and_write_mzml(
             config=self.default_config,
             final_filepath=os.path.join(self.test_dir, "test.mzML"),
-            update_queue=None,
             return_data_only=True
         )
         self.assertIsInstance(result, tuple)
@@ -71,7 +70,6 @@ class TestSimulation(unittest.TestCase):
         _, spectra_inhomogeneity = execute_simulation_and_write_mzml(
             config=config_inhomogeneity,
             final_filepath=os.path.join(self.test_dir, "test_inhomogeneity.mzML"),
-            update_queue=None,
             return_data_only=True
         )
 
@@ -81,7 +79,6 @@ class TestSimulation(unittest.TestCase):
         _, spectra_no_inhomogeneity = execute_simulation_and_write_mzml(
             config=config_no_inhomogeneity,
             final_filepath=os.path.join(self.test_dir, "test_no_inhomogeneity.mzML"),
-            update_queue=None,
             return_data_only=True
         )
 
@@ -92,7 +89,7 @@ class TestSimulation(unittest.TestCase):
         config = copy.deepcopy(self.default_config)
         config.protein_masses = [-100]
         # execute_simulation_and_write_mzml returns False on validation error, it doesn't raise
-        result = execute_simulation_and_write_mzml(config, "test.mzML", None)
+        result = execute_simulation_and_write_mzml(config, "test.mzML")
         self.assertFalse(result)
 
     def test_file_is_created(self):
@@ -100,7 +97,6 @@ class TestSimulation(unittest.TestCase):
         success = execute_simulation_and_write_mzml(
             config=self.default_config,
             final_filepath=filepath,
-            update_queue=None,
             return_data_only=False
         )
         self.assertTrue(success)
@@ -114,7 +110,6 @@ class TestSimulation(unittest.TestCase):
         mz_range, spectra = execute_simulation_and_write_mzml(
             config=self.default_config,
             final_filepath=os.path.join(self.test_dir, "test.mzML"),
-            update_queue=None,
             return_data_only=True
         )
         spectrum = spectra[0][0] # First protein, first scan
@@ -156,7 +151,7 @@ class TestSimulation(unittest.TestCase):
 
         # 1. Get the result from the parallel implementation
         mz_range_parallel, spectra_parallel = execute_simulation_and_write_mzml(
-            config=config, final_filepath="", update_queue=None, return_data_only=True
+            config=config, final_filepath="", return_data_only=True
         )
 
         # 2. Manually run the sequential logic to get the expected result
@@ -192,7 +187,7 @@ class TestSimulation(unittest.TestCase):
             mz_range=mz_range_seq, all_clean_spectra=all_clean_spectra_seq, num_scans=lc.num_scans,
             gaussian_std_dev=lc.gaussian_std_dev, lc_tailing_factor=lc.lc_tailing_factor,
             seed=common.seed, noise_option=common.noise_option, pink_noise_enabled=common.pink_noise_enabled,
-            apex_scans=None, update_queue=None
+            apex_scans=None, progress_callback=None
         )
 
         # 3. Compare the results


### PR DESCRIPTION
Replaced the direct use of `multiprocessing.Queue` for progress reporting with a generic `progress_callback` function. This decouples the core simulation engine from the GUI, improving modularity and testability.

The main simulation orchestration has been encapsulated within a new `SimulationRunner` class, and its `run` method has been simplified by extracting helper methods for task preparation and result aggregation.

The calculation of LC apex scans based on hydrophobicity has been moved from `simulation.py` to the more appropriate `retention_time.py` module.

The test suite has been updated to reflect these API changes, and all tests pass.