### PR TITLE
refactor: Remove PTM feature from peptide map simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ This application generates simulated mass spectrometry data (`.mzML` files) for 
 - **Mass Inhomogeneity:** Simulate protein conformational broadening by defining a standard deviation for the average protein mass.
 - **EMG Peak Shape:** Model more realistic chromatographic profiles by applying an Exponentially Modified Gaussian (EMG) shape with a configurable tailing factor.
 - **1/f Noise:** Optionally add an extra layer of `1/f` (pink) noise for more realistic electronic noise simulation.
+- **Post-Translational Modifications (PTMs):** Stochastically apply common PTMs like oxidation or deamidation to protein and peptide sequences.
+
+### Post-Translational Modification (PTM) Simulation
+
+This feature allows for the stochastic application of post-translational modifications to protein sequences, adding another layer of realism to the simulated data. The PTMs are defined by their mass shift, the target amino acid residue, and the probability of the modification occurring at any given site.
+
+This functionality is available in the **Antibody Simulation** tab.
+
+**Configuration:**
+
+In the **Antibody Simulation** tab, each chain has a "PTMs..." button, which opens a dedicated editor to configure PTMs for that specific chain. This allows for different modifications to be applied to heavy and light chains, for example.
+
+For each PTM, you can configure:
+*   **Enabled**: A checkbox to turn the simulation of this PTM on or off.
+*   **Probability**: A value from 0.0 to 1.0 representing the chance that the modification will occur on any given target residue. For example, a probability of 0.25 means that each target residue has a 25% chance of being modified.
 
 ## Simulation Modules
 

--- a/src/spec_generator/config.py
+++ b/src/spec_generator/config.py
@@ -1,5 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Tuple, Dict
+
+from .logic.ptm import Ptm
 
 @dataclass
 class CommonParams:
@@ -66,6 +68,7 @@ class Chain:
     seq: str
     pyro_glu: bool
     k_loss: bool
+    ptms: List[Ptm] = field(default_factory=list)
 
 @dataclass
 class AntibodySimConfig:

--- a/src/spec_generator/logic/antibody.py
+++ b/src/spec_generator/logic/antibody.py
@@ -14,6 +14,7 @@ from ..core.constants import DISULFIDE_MASS_LOSS
 from .simulation import execute_simulation_and_write_mzml
 from ..config import AntibodySimConfig, SpectrumGeneratorConfig
 from .retention_time import KYTE_DOOLITTLE
+from .ptm import calculate_ptm_mass_shift
 
 
 def calculate_assembly_properties(chains: list[dict], assemblies: list[dict]) -> list[dict]:
@@ -45,6 +46,12 @@ def calculate_assembly_properties(chains: list[dict], assemblies: list[dict]) ->
                     final_sequence = final_sequence[:-1]
 
                 chain_mass = mass.calculate_mass(sequence=final_sequence, average=True)
+
+                # Apply stochastic PTMs
+                ptm_configs = chain.get('ptms', [])
+                if ptm_configs:
+                    ptm_mass_shift = calculate_ptm_mass_shift(final_sequence, ptm_configs)
+                    chain_mass += ptm_mass_shift
 
                 if pyro_glu and (original_sequence.startswith('E') or original_sequence.startswith('Q')):
                     chain_mass -= water_mass_loss

--- a/src/spec_generator/logic/ptm.py
+++ b/src/spec_generator/logic/ptm.py
@@ -1,0 +1,68 @@
+"""
+This module defines the data structures and core logic for handling
+Post-Translational Modifications (PTMs). It allows for the stochastic
+application of PTMs to a protein sequence to calculate a total mass shift.
+"""
+import random
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class Ptm:
+    """
+    Represents a single Post-Translational Modification.
+
+    Attributes:
+        name: The common name of the modification (e.g., "Oxidation").
+        mass_shift: The mass difference (in Daltons) to be added to the peptide.
+        residue: The one-letter amino acid code that this PTM targets.
+        probability: The chance (0.0 to 1.0) that this PTM will occur at any given target site.
+    """
+    name: str
+    mass_shift: float
+    residue: str
+    probability: float = 0.0
+
+# A library of common PTMs that can be used as defaults in the GUI.
+# Users can select from this list and customize the probability.
+DEFAULT_PTMS = {
+    "Oxidation": Ptm(name="Oxidation", mass_shift=15.994915, residue="M"),
+    "Deamidation": Ptm(name="Deamidation", mass_shift=0.984016, residue="N"),
+    "Guanidination": Ptm(name="Guanidination", mass_shift=42.0218, residue="K"),
+    "Methylation": Ptm(name="Methylation", mass_shift=14.01565, residue="K"),
+}
+
+def calculate_ptm_mass_shift(sequence: str, ptm_configs: List[Ptm]) -> float:
+    """
+    Calculates the total mass shift for a sequence based on a list of PTMs,
+    applied stochastically.
+
+    Args:
+        sequence: The amino acid sequence of the protein/peptide.
+        ptm_configs: A list of Ptm objects, each configured with a specific
+                     probability for this simulation.
+
+    Returns:
+        The total mass shift from all applied PTMs.
+    """
+    total_mass_shift = 0.0
+    if not ptm_configs:
+        return total_mass_shift
+
+    # Create a map of residue -> list of PTMs for efficient lookup
+    ptm_map = {}
+    for ptm in ptm_configs:
+        if ptm.residue not in ptm_map:
+            ptm_map[ptm.residue] = []
+        ptm_map[ptm.residue].append(ptm)
+
+    # Iterate through each amino acid in the sequence
+    for amino_acid in sequence:
+        # Check if this amino acid is a target for any configured PTMs
+        if amino_acid in ptm_map:
+            # For each PTM that targets this amino acid, roll the dice
+            for ptm in ptm_map[amino_acid]:
+                if ptm.probability > 0 and random.random() < ptm.probability:
+                    total_mass_shift += ptm.mass_shift
+
+    return total_mass_shift

--- a/tests/test_ptm.py
+++ b/tests/test_ptm.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import patch
+from spec_generator.logic.ptm import calculate_ptm_mass_shift, Ptm
+
+# --- Test Constants ---
+OXIDATION = Ptm(name="Oxidation", mass_shift=15.9949, residue="M", probability=0.5)
+METHYLATION = Ptm(name="Methylation", mass_shift=14.0157, residue="K", probability=0.3)
+DEAMIDATION = Ptm(name="Deamidation", mass_shift=0.9840, residue="N", probability=0.8)
+
+# --- Test Cases ---
+
+def test_no_ptms_configured():
+    """
+    Tests that the mass shift is zero when no PTMs are provided.
+    """
+    assert calculate_ptm_mass_shift("PEPTIDE", []) == 0.0
+
+def test_no_target_residues_in_sequence():
+    """
+    Tests that the mass shift is zero when the sequence contains no target residues.
+    """
+    assert calculate_ptm_mass_shift("PEPTIDE", [OXIDATION, METHYLATION]) == 0.0
+
+def test_guaranteed_ptm_application():
+    """
+    Tests that the mass shift is correctly calculated when a PTM has a probability of 1.0.
+    """
+    guaranteed_oxidation = Ptm(name="Oxidation", mass_shift=15.9949, residue="M", probability=1.0)
+    sequence = "MPEPTIDEM"  # Contains two methionine residues
+    expected_shift = 2 * guaranteed_oxidation.mass_shift
+    assert calculate_ptm_mass_shift(sequence, [guaranteed_oxidation]) == pytest.approx(expected_shift)
+
+def test_impossible_ptm_application():
+    """
+    Tests that the mass shift is zero when a PTM has a probability of 0.0.
+    """
+    impossible_oxidation = Ptm(name="Oxidation", mass_shift=15.9949, residue="M", probability=0.0)
+    sequence = "MPEPTIDEM"
+    assert calculate_ptm_mass_shift(sequence, [impossible_oxidation]) == 0.0
+
+@patch('spec_generator.logic.ptm.random.random')
+def test_stochastic_ptm_is_applied(mock_random):
+    """
+    Tests that a PTM is applied when random.random() returns a value below the probability.
+    """
+    mock_random.return_value = 0.4  # 0.4 is less than OXIDATION's probability of 0.5
+    sequence = "M"
+    assert calculate_ptm_mass_shift(sequence, [OXIDATION]) == pytest.approx(OXIDATION.mass_shift)
+
+@patch('spec_generator.logic.ptm.random.random')
+def test_stochastic_ptm_is_not_applied(mock_random):
+    """
+    Tests that a PTM is not applied when random.random() returns a value above the probability.
+    """
+    mock_random.return_value = 0.6  # 0.6 is greater than OXIDATION's probability of 0.5
+    sequence = "M"
+    assert calculate_ptm_mass_shift(sequence, [OXIDATION]) == 0.0
+
+@patch('spec_generator.logic.ptm.random.random')
+def test_multiple_sites_and_ptms_stochastic(mock_random):
+    """
+    Tests a complex scenario with multiple PTMs and multiple sites, mocking the
+    random number generator to control the outcome.
+    """
+    # Sequence has two 'M's, one 'K', and one 'N'
+    sequence = "MPEPTIDEMNK"
+
+    # The function iterates through the sequence: M, M, N, K
+    # We expect random.random() to be called for each potential site.
+    # 1. First M:  random=0.2 -> 0.2 < 0.5 (Oxidation prob) -> APPLY
+    # 2. Second M: random=0.7 -> 0.7 > 0.5 (Oxidation prob) -> SKIP
+    # 3. N:        random=0.5 -> 0.5 < 0.8 (Deamidation prob) -> APPLY
+    # 4. K:        random=0.4 -> 0.4 > 0.3 (Methylation prob) -> SKIP
+    mock_random.side_effect = [0.2, 0.7, 0.5, 0.4]
+
+    ptm_configs = [OXIDATION, METHYLATION, DEAMIDATION]
+
+    expected_shift = OXIDATION.mass_shift + DEAMIDATION.mass_shift
+    actual_shift = calculate_ptm_mass_shift(sequence, ptm_configs)
+
+    assert actual_shift == pytest.approx(expected_shift)
+    assert mock_random.call_count == 4
+
+def test_multiple_ptms_on_same_residue_type():
+    """
+    Tests that multiple different PTMs can target the same amino acid type.
+    """
+    # Both PTMs target Lysine (K)
+    ptm1 = Ptm(name="Mod1", mass_shift=10.0, residue="K", probability=1.0)
+    ptm2 = Ptm(name="Mod2", mass_shift=5.0, residue="K", probability=1.0)
+
+    sequence = "K"
+    expected_shift = ptm1.mass_shift + ptm2.mass_shift
+    assert calculate_ptm_mass_shift(sequence, [ptm1, ptm2]) == pytest.approx(expected_shift)


### PR DESCRIPTION
This commit removes the Post-Translational Modification (PTM) simulation functionality specifically from the peptide map module, as requested.

The initial implementation for peptide maps resulted in an "average" mass shift rather than distinct peaks for modified and unmodified species, which was not the desired behavior for that workflow.

The PTM feature remains fully functional for the Antibody Simulation module.

Changes include:
- Removing the PTM editor from the Peptide Map GUI tab.
- Removing the PTM configuration from the `PeptideMapSimConfig`.
- Reverting the logic for PTM calculations in the peptide map pipeline (`peptide_map.py`, `spectrum.py`, `peptide_isotopes.py`).
- Updating `README.md` to reflect that PTM simulation is now only available for the antibody module.