### PR TITLE
feat: Enhance MS/MS fragmentation module

### DIFF
--- a/src/spec_generator/core/constants.py
+++ b/src/spec_generator/core/constants.py
@@ -32,19 +32,37 @@ from pyteomics.mass import std_aa_mass as AMINO_ACID_MASSES
 # --- Masses for Fragmentation ---
 # Monoisotopic masses of amino acid residues from pyteomics.mass
 
-# Mass of water and ammonia for fragment ion calculation. Using monoisotopic masses.
-# H = 1.007825, O = 15.994915, N = 14.003074
+# Mass of water, ammonia, and carbon monoxide for fragment ion calculation.
+# Using monoisotopic masses.
+# H = 1.007825, O = 15.994915, N = 14.003074, C = 12.000000
 H2O_MASS = 18.010565
 NH3_MASS = 17.026549
+CO_MASS = 27.994915
 
 # Mass modifications for different fragment ion types.
 # These values are added to the sum of residue masses of the fragment.
 # This gives the mass of the neutral fragment.
 FRAGMENT_ION_MODIFICATIONS = {
     # N-terminal ions
+    'a': -CO_MASS,
     'b': 0.0,
     'c': NH3_MASS,
     # C-terminal ions
+    'x': CO_MASS,
     'y': H2O_MASS,
     'z': H2O_MASS - NH3_MASS,
+}
+
+# Amino acids prone to neutral loss events.
+# The keys are the single-letter amino acid codes, and the values are a list
+# of mass losses (e.g., H2O, NH3) that can occur.
+NEUTRAL_LOSS_RULES = {
+    'S': [H2O_MASS],  # Serine -> loss of water
+    'T': [H2O_MASS],  # Threonine -> loss of water
+    'D': [H2O_MASS],  # Aspartic Acid -> loss of water
+    'E': [H2O_MASS],  # Glutamic Acid -> loss of water
+    'N': [NH3_MASS],  # Asparagine -> loss of ammonia
+    'Q': [NH3_MASS],  # Glutamine -> loss of ammonia
+    'K': [NH3_MASS],  # Lysine -> loss of ammonia
+    'R': [NH3_MASS],  # Arginine -> loss of ammonia
 }

--- a/src/spec_generator/logic/fragmentation.py
+++ b/src/spec_generator/logic/fragmentation.py
@@ -1,15 +1,130 @@
 """
 This module provides functions for generating fragment ions from peptide sequences.
 """
+from typing import Optional
 from ..core.constants import (
     AMINO_ACID_MASSES,
     FRAGMENT_ION_MODIFICATIONS,
+    NEUTRAL_LOSS_RULES,
     PROTON_MASS,
 )
 
 
+def _calculate_prefix_masses(
+    sequence: str, ptms: Optional[dict[int, float]] = None
+) -> list[float]:
+    """
+    Calculates the cumulative mass from the N-terminus for each residue,
+    including any PTMs.
+    """
+    ptms = ptms or {}
+    prefix_masses = [0.0] * len(sequence)
+    current_mass = 0.0
+    for i, aa in enumerate(sequence):
+        current_mass += AMINO_ACID_MASSES.get(aa, 0.0)
+        if i in ptms:
+            current_mass += ptms[i]
+        prefix_masses[i] = current_mass
+    return prefix_masses
+
+
+def _calculate_suffix_masses(
+    sequence: str, ptms: Optional[dict[int, float]] = None
+) -> list[float]:
+    """
+    Calculates the cumulative mass from the C-terminus for each residue,
+    including any PTMs.
+    """
+    ptms = ptms or {}
+    suffix_masses = [0.0] * len(sequence)
+    current_mass = 0.0
+    for i, aa in enumerate(reversed(sequence)):
+        current_mass += AMINO_ACID_MASSES.get(aa, 0.0)
+        # Original index from the left
+        original_index = len(sequence) - 1 - i
+        if original_index in ptms:
+            current_mass += ptms[original_index]
+        suffix_masses[original_index] = current_mass
+    return suffix_masses
+
+
+def _generate_n_terminal_ions(
+    sequence: str, prefix_masses: list[float], ion_type: str, charges: list[int]
+) -> list[float]:
+    """Generates m/z values for N-terminal ions (a, b, c), including neutral losses."""
+    fragment_mzs = []
+    modification = FRAGMENT_ION_MODIFICATIONS.get(ion_type)
+    if modification is None:
+        return []
+
+    for i in range(len(prefix_masses) - 1):
+        neutral_mass = prefix_masses[i] + modification
+        fragment_sequence = sequence[: i + 1]
+
+        # Add the primary ion
+        for charge in charges:
+            if charge == 0: continue
+            mz = (neutral_mass + charge * PROTON_MASS) / charge
+            fragment_mzs.append(mz)
+
+        # Handle neutral losses
+        possible_losses = set()
+        for aa in fragment_sequence:
+            if aa in NEUTRAL_LOSS_RULES:
+                for loss in NEUTRAL_LOSS_RULES[aa]:
+                    possible_losses.add(loss)
+
+        for loss_mass in possible_losses:
+            loss_neutral_mass = neutral_mass - loss_mass
+            for charge in charges:
+                if charge == 0: continue
+                mz = (loss_neutral_mass + charge * PROTON_MASS) / charge
+                fragment_mzs.append(mz)
+
+    return fragment_mzs
+
+
+def _generate_c_terminal_ions(
+    sequence: str, suffix_masses: list[float], ion_type: str, charges: list[int]
+) -> list[float]:
+    """Generates m/z values for C-terminal ions (x, y, z), including neutral losses."""
+    fragment_mzs = []
+    modification = FRAGMENT_ION_MODIFICATIONS.get(ion_type)
+    if modification is None:
+        return []
+
+    for i in range(len(suffix_masses) - 1):
+        neutral_mass = suffix_masses[i + 1] + modification
+        fragment_sequence = sequence[i + 1 :]
+
+        # Add the primary ion
+        for charge in charges:
+            if charge == 0: continue
+            mz = (neutral_mass + charge * PROTON_MASS) / charge
+            fragment_mzs.append(mz)
+
+        # Handle neutral losses
+        possible_losses = set()
+        for aa in fragment_sequence:
+            if aa in NEUTRAL_LOSS_RULES:
+                for loss in NEUTRAL_LOSS_RULES[aa]:
+                    possible_losses.add(loss)
+
+        for loss_mass in possible_losses:
+            loss_neutral_mass = neutral_mass - loss_mass
+            for charge in charges:
+                if charge == 0: continue
+                mz = (loss_neutral_mass + charge * PROTON_MASS) / charge
+                fragment_mzs.append(mz)
+
+    return fragment_mzs
+
+
 def generate_fragment_ions(
-    sequence: str, ion_types: list[str], charges: list[int]
+    sequence: str,
+    ion_types: list[str],
+    charges: list[int],
+    ptms: Optional[dict[int, float]] = None,
 ) -> list[float]:
     """
     Generates a list of m/z values for specified fragment ions.
@@ -18,6 +133,8 @@ def generate_fragment_ions(
         sequence: The amino acid sequence of the peptide.
         ion_types: A list of ion types to generate (e.g., ['b', 'y']).
         charges: A list of charge states to consider for each fragment.
+        ptms: A dictionary of post-translational modifications, where keys are
+              0-based residue indices and values are the mass shifts.
 
     Returns:
         A list of calculated m/z values for the fragment ions.
@@ -26,46 +143,20 @@ def generate_fragment_ions(
         return []
 
     fragment_mzs = []
-    n_term_ion_types = {'b', 'c'}
-    c_term_ion_types = {'y', 'z'}
+    n_term_ion_types = {'a', 'b', 'c'}
+    c_term_ion_types = {'x', 'y', 'z'}
 
-    # Pre-calculate prefix sums of residue masses for efficient N-terminal ion calculation
-    prefix_masses = [0.0] * len(sequence)
-    current_mass = 0.0
-    for i, aa in enumerate(sequence):
-        current_mass += AMINO_ACID_MASSES.get(aa, 0.0)
-        prefix_masses[i] = current_mass
-
-    # Pre-calculate suffix sums of residue masses for efficient C-terminal ion calculation
-    suffix_masses = [0.0] * len(sequence)
-    current_mass = 0.0
-    # Iterate backwards to get sums from C-terminus
-    for i, aa in enumerate(reversed(sequence)):
-        current_mass += AMINO_ACID_MASSES.get(aa, 0.0)
-        suffix_masses[len(sequence) - 1 - i] = current_mass
+    prefix_masses = _calculate_prefix_masses(sequence, ptms)
+    suffix_masses = _calculate_suffix_masses(sequence, ptms)
 
     for ion_type in ion_types:
-        modification = FRAGMENT_ION_MODIFICATIONS.get(ion_type)
-        if modification is None:
-            continue  # Skip unsupported ion types
-
-        # Iterate through all possible cleavage points (len(sequence) - 1 points)
-        for i in range(len(sequence) - 1):
-            neutral_mass = 0.0
-            if ion_type in n_term_ion_types:
-                # Fragment is from N-terminus, e.g., b1, b2, ...
-                # The fragment length is i + 1, corresponding to prefix_masses[i]
-                neutral_mass = prefix_masses[i] + modification
-            elif ion_type in c_term_ion_types:
-                # Fragment is from C-terminus, e.g., y1, y2, ...
-                # The fragment length is len(sequence) - (i + 1)
-                # This corresponds to suffix_masses[i+1]
-                neutral_mass = suffix_masses[i + 1] + modification
-
-            if neutral_mass > 0:
-                for charge in charges:
-                    if charge == 0: continue
-                    mz = (neutral_mass + charge * PROTON_MASS) / charge
-                    fragment_mzs.append(mz)
+        if ion_type in n_term_ion_types:
+            fragment_mzs.extend(
+                _generate_n_terminal_ions(sequence, prefix_masses, ion_type, charges)
+            )
+        elif ion_type in c_term_ion_types:
+            fragment_mzs.extend(
+                _generate_c_terminal_ions(sequence, suffix_masses, ion_type, charges)
+            )
 
     return sorted(set(fragment_mzs))

--- a/tests/test_fragmentation.py
+++ b/tests/test_fragmentation.py
@@ -1,46 +1,47 @@
 import unittest
 import numpy as np
 from spec_generator.logic.fragmentation import generate_fragment_ions
-from spec_generator.core.constants import AMINO_ACID_MASSES, PROTON_MASS, H2O_MASS
+from spec_generator.core.constants import (
+    AMINO_ACID_MASSES,
+    PROTON_MASS,
+    H2O_MASS,
+    CO_MASS,
+    NH3_MASS,
+)
+
 
 class TestFragmentation(unittest.TestCase):
-    def test_generate_fragment_ions(self):
+    def test_generate_fragment_ions_base(self):
         """
-        Test generation of fragment ions for a simple peptide.
+        Test generation of basic b and y ions for a simple peptide.
+        This test checks that the core logic remains correct after refactoring.
         """
         sequence = "PEPTIDE"
-        ion_types = ['b', 'y']
+        ion_types = ["b", "y"]
         charges = [1, 2]
 
-        # Expected masses for PEPTIDE
-        # P = 97.052764
-        # E = 129.042593
-        # P = 97.052764
-        # T = 101.047679
-        # I = 113.084064
-        # D = 115.026943
-        # E = 129.042593
+        # Use constants to avoid magic numbers
+        P, E, T, I, D = (
+            AMINO_ACID_MASSES['P'], AMINO_ACID_MASSES['E'], AMINO_ACID_MASSES['T'],
+            AMINO_ACID_MASSES['I'], AMINO_ACID_MASSES['D']
+        )
 
-        # Neutral masses of b ions
         b_ions_neutral = [
-            97.052764,  # b1
-            97.052764 + 129.042593,  # b2
-            97.052764 + 129.042593 + 97.052764,  # b3
-            97.052764 + 129.042593 + 97.052764 + 101.047679,  # b4
-            97.052764 + 129.042593 + 97.052764 + 101.047679 + 113.084064,  # b5
-            97.052764 + 129.042593 + 97.052764 + 101.047679 + 113.084064 + 115.026943,  # b6
+            P,
+            P + E,
+            P + E + P,
+            P + E + P + T,
+            P + E + P + T + I,
+            P + E + P + T + I + D,
         ]
-
-        # Neutral masses of y ions
         y_ions_neutral = [
-            129.042593 + H2O_MASS,  # y1
-            129.042593 + 115.026943 + H2O_MASS,  # y2
-            129.042593 + 115.026943 + 113.084064 + H2O_MASS,  # y3
-            129.042593 + 115.026943 + 113.084064 + 101.047679 + H2O_MASS,  # y4
-            129.042593 + 115.026943 + 113.084064 + 101.047679 + 97.052764 + H2O_MASS,  # y5
-            129.042593 + 115.026943 + 113.084064 + 101.047679 + 97.052764 + 129.042593 + H2O_MASS,  # y6
+            E + H2O_MASS,
+            D + E + H2O_MASS,
+            I + D + E + H2O_MASS,
+            T + I + D + E + H2O_MASS,
+            P + T + I + D + E + H2O_MASS,
+            E + P + T + I + D + E + H2O_MASS,
         ]
-
         expected_mzs = []
         for mass in b_ions_neutral + y_ions_neutral:
             for charge in charges:
@@ -48,7 +49,89 @@ class TestFragmentation(unittest.TestCase):
 
         result_mzs = generate_fragment_ions(sequence, ion_types, charges)
 
+        expected_set = {round(mz, 4) for mz in expected_mzs}
+        result_set = {round(mz, 4) for mz in result_mzs}
+
+        # Check that all expected base ions are present (neutral loss ions may also be present)
+        self.assertTrue(expected_set.issubset(result_set),
+                        f"Missing ions: {expected_set - result_set}")
+
+    def test_a_and_x_ions(self):
+        """Test generation of a and x ions."""
+        sequence = "GAV"
+        ion_types = ["a", "x"]
+        charges = [1]
+
+        G, A, V = AMINO_ACID_MASSES['G'], AMINO_ACID_MASSES['A'], AMINO_ACID_MASSES['V']
+
+        a_masses = [G - CO_MASS, G + A - CO_MASS]
+        x_masses = [V + CO_MASS, A + V + CO_MASS]
+
+        expected_mzs = []
+        for mass in a_masses + x_masses:
+            expected_mzs.append((mass + PROTON_MASS) / 1)
+
+        result_mzs = generate_fragment_ions(sequence, ion_types, charges)
         np.testing.assert_allclose(sorted(result_mzs), sorted(expected_mzs), rtol=1e-5)
 
-if __name__ == '__main__':
+    def test_neutral_loss(self):
+        """Test generation of ions with neutral losses."""
+        sequence = "TEST"
+        ion_types = ["b"]
+        charges = [1]
+
+        T, E, S = AMINO_ACID_MASSES['T'], AMINO_ACID_MASSES['E'], AMINO_ACID_MASSES['S']
+
+        b2_mass = T + E
+        b3_mass = T + E + S
+
+        # E, S, T can all lose H2O.
+        # Expected ions: b2, b2-H2O, b3, b3-H2O
+        expected_masses = [
+            b2_mass,
+            b2_mass - H2O_MASS,
+            b3_mass,
+            b3_mass - H2O_MASS,
+        ]
+
+        result_mzs = generate_fragment_ions(sequence, ion_types, charges)
+
+        expected_mzs = [(m + PROTON_MASS) / 1 for m in expected_masses]
+        result_set = {round(mz, 4) for mz in result_mzs}
+        expected_set = {round(mz, 4) for mz in expected_mzs}
+
+        self.assertTrue(expected_set.issubset(result_set))
+
+    def test_ptm_fragmentation(self):
+        """Test that PTMs are correctly handled in fragment masses."""
+        sequence = "PEPTIDE"
+        ion_types = ["b", "y"]
+        charges = [1]
+
+        P, E, T, I, D = (
+            AMINO_ACID_MASSES['P'], AMINO_ACID_MASSES['E'], AMINO_ACID_MASSES['T'],
+            AMINO_ACID_MASSES['I'], AMINO_ACID_MASSES['D']
+        )
+        phos_mass = 79.966331
+        ptms = {3: phos_mass}  # Phosphorylation of T at index 3
+
+        b3_mass = P + E + P
+        b4_mass_phos = P + E + P + T + phos_mass
+
+        y3_mass = I + D + E + H2O_MASS
+        y4_mass_phos = T + I + D + E + H2O_MASS + phos_mass
+
+        expected_masses = [b3_mass, b4_mass_phos, y3_mass, y4_mass_phos]
+        expected_mzs = [(m + PROTON_MASS) / 1 for m in expected_masses]
+
+        result_mzs = generate_fragment_ions(sequence, ion_types, charges, ptms=ptms)
+
+        result_set = {round(mz, 4) for mz in result_mzs}
+        expected_set = {round(mz, 4) for mz in expected_mzs}
+
+        self.assertTrue(expected_set.issubset(result_set),
+                        f"Missing PTM ions: {expected_set - result_set}")
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit significantly enhances the MS/MS fragmentation module by adding support for a wider range of ion types, post-translational modifications (PTMs), and neutral losses.

Key improvements:
- The core `generate_fragment_ions` function has been refactored for better readability and extensibility, with logic broken down into smaller helper functions.
- Added support for 'a' and 'x' fragment ions in addition to the existing 'b', 'y', 'c', and 'z' ions.
- Implemented logic to handle neutral losses of H2O and NH3 from fragments containing susceptible amino acids (S, T, D, E, N, Q, K, R).
- The fragmentation logic now correctly accounts for Post-Translational Modifications (PTMs) by accepting a dictionary of mass shifts for specific residues.
- Expanded the unit test suite in `tests/test_fragmentation.py` with new tests to validate the correctness of a/x ions, neutral loss calculations, and PTM handling.