### PR TITLE
feat: Add foundation for MS/MS data generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent Instructions
+
+This document provides special instructions for software agents working in this repository.
+
+## Testing Environment Setup
+
+**IMPORTANT:** The testing environment in this repository is non-standard. The `pytest` command is executed within an isolated `pipx` virtual environment.
+
+If you need to install or update dependencies for testing, a standard `pip install` command will **not** work, as it will target the wrong environment. This will result in `ModuleNotFoundError` when you try to run the tests.
+
+To correctly install dependencies for the testing environment, you **must** use the following command format, which targets the python executable inside the `pipx` virtual environment for `pytest`:
+
+```bash
+/home/jules/.local/share/pipx/venvs/pytest/bin/python -m pip install -e .[test]
+```
+
+Always use this command to set up the test environment before running `pytest`. This will ensure that all dependencies are installed in the correct location and that the tests can find the required modules.

--- a/src/spec_generator/config.py
+++ b/src/spec_generator/config.py
@@ -43,6 +43,7 @@ class SpectrumGeneratorConfig:
     intensity_scalars: List[float]
     mass_inhomogeneity: float
     hydrophobicity_scores: List[float] | None = None
+    peptide_sequences: List[str] | None = None
 
 @dataclass
 class CovalentBindingConfig:

--- a/src/spec_generator/core/spectrum.py
+++ b/src/spec_generator/core/spectrum.py
@@ -1,6 +1,8 @@
 import math
 import multiprocessing
 import itertools
+from dataclasses import dataclass, field
+from typing import List
 import numpy as np
 import numba
 
@@ -9,6 +11,7 @@ from .constants import (BASE_INTENSITY_SCALAR, FWHM_TO_SIGMA, MZ_SCALE_FACTOR,
 from .isotopes import isotope_calculator
 from .peptide_isotopes import peptide_isotope_calculator
 from ..logic.fragmentation import generate_fragment_ions
+from .types import FragmentationEvent
 
 
 @numba.jit(nopython=True, fastmath=True)

--- a/src/spec_generator/core/types.py
+++ b/src/spec_generator/core/types.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+from typing import List
+import numpy as np
+
+@dataclass
+class Spectrum:
+    """
+    Represents a mass spectrum.
+
+    Attributes:
+        mz: A numpy array of m/z values.
+        intensity: A numpy array of intensity values.
+    """
+    mz: np.ndarray
+    intensity: np.ndarray
+
+@dataclass
+class FragmentationEvent:
+    """
+    Represents a single fragmentation event.
+
+    Attributes:
+        precursor_mz: The m/z of the precursor ion.
+        precursor_charge: The charge of the precursor ion.
+        rt: The retention time of the fragmentation event.
+        intensity: The intensity of the precursor ion.
+        fragments: A Spectrum object containing the fragment ions.
+    """
+
+    precursor_mz: float
+    precursor_charge: int
+    rt: float
+    intensity: float
+    fragments: Spectrum
+
+@dataclass
+class MSMSSpectrum:
+    """
+    Represents an MS/MS spectrum, containing a list of fragmentation events.
+    """
+    rt: float
+    precursor_mz: float
+    precursor_charge: int
+    fragmentation_events: List[FragmentationEvent] = field(default_factory=list)


### PR DESCRIPTION
This commit introduces the foundational structures and logic for generating MS/MS spectra and including them in the mzML output.

Key changes:
- Created new data classes `Spectrum`, `FragmentationEvent`, and `MSMSSpectrum` in a new `types.py` file to model MS/MS data.
- Added a new function `generate_fragmentation_events` to `fragmentation.py` to generate fragment ions for a given peptide sequence.
- Updated `mzml.py` to handle `MSMSSpectrum` objects and generate the corresponding MS2 spectrum elements in the mzML file.
- Added a temporary, non-user-facing implementation in `simulation.py` to generate dummy MS/MS data for testing purposes.
- Added `AGENTS.md` to document the non-standard testing environment.